### PR TITLE
Changed logic of multiaggregate persistence read.

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,4 +1,6 @@
-## vNext
+## 0.17.1
+
+- Changed logic for MultiPartitionRead because it used index not global position and it is not correct.
 
 ## 0.17.0
 

--- a/src/NStore.BaseSqlPersistence/AbstractSqlPersistence.cs
+++ b/src/NStore.BaseSqlPersistence/AbstractSqlPersistence.cs
@@ -398,16 +398,16 @@ namespace NStore.BaseSqlPersistence
 
         protected async Task ScanRange(
             IEnumerable<string> partitionIdsList,
-            long lowerIndexInclusive,
-            long upperIndexInclusive,
+            long lowerPositionInclusive,
+            long upperPositionInclusive,
             bool descending,
             ISubscription subscription,
             CancellationToken cancellationToken)
         {
             var sql = Options.GetRangeMultiplePartitionSelectChunksSql(
                 partitionIdsList,
-                lowerIndexInclusive: lowerIndexInclusive,
-                upperIndexInclusive: upperIndexInclusive,
+                lowerIndexInclusive: lowerPositionInclusive,
+                upperIndexInclusive: upperPositionInclusive,
                 descending: descending);
 
             using (var context = await Options.GetContextAsync(cancellationToken).ConfigureAwait(false))
@@ -420,28 +420,28 @@ namespace NStore.BaseSqlPersistence
                         context.AddParam(command, $"@p{i++}", id);
                     }
 
-                    if (lowerIndexInclusive > 0 && lowerIndexInclusive != Int64.MaxValue)
+                    if (lowerPositionInclusive > 0 && lowerPositionInclusive != Int64.MaxValue)
                     {
-                        context.AddParam(command, "@lowerIndexInclusive", lowerIndexInclusive);
+                        context.AddParam(command, "@lowerIndexInclusive", lowerPositionInclusive);
                     }
 
-                    if (upperIndexInclusive > 0 && upperIndexInclusive != Int64.MaxValue)
+                    if (upperPositionInclusive > 0 && upperPositionInclusive != Int64.MaxValue)
                     {
-                        context.AddParam(command, "@upperIndexInclusive", upperIndexInclusive);
+                        context.AddParam(command, "@upperIndexInclusive", upperPositionInclusive);
                     }
 
-                    await PushToSubscriber(command, descending ? upperIndexInclusive : lowerIndexInclusive,
+                    await PushToSubscriber(command, descending ? upperPositionInclusive : lowerPositionInclusive,
                             subscription, false, cancellationToken)
                         .ConfigureAwait(false);
                 }
             }
         }
 
-        public async Task ReadForwardMultiplePartitionsAsync(
+        public async Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             IEnumerable<string> partitionIdsList,
-            long fromLowerIndexInclusive,
+            long fromLowerPositionInclusive,
             ISubscription subscription,
-            long toUpperIndexInclusive,
+            long toUpperPositionInclusive,
             CancellationToken cancellationToken)
         {
             if (partitionIdsList is null)
@@ -456,8 +456,8 @@ namespace NStore.BaseSqlPersistence
 
             await ScanRange(
                     partitionIdsList: partitionIdsList,
-                    lowerIndexInclusive: fromLowerIndexInclusive,
-                    upperIndexInclusive: toUpperIndexInclusive,
+                    lowerPositionInclusive: fromLowerPositionInclusive,
+                    upperPositionInclusive: toUpperPositionInclusive,
 
                     @descending: false,
                     subscription: subscription,

--- a/src/NStore.Core/InMemory/InMemoryPartition.cs
+++ b/src/NStore.Core/InMemory/InMemoryPartition.cs
@@ -45,7 +45,25 @@ namespace NStore.Core.InMemory
             _lockSlim.ExitReadLock();
             await PushToSubscriber(fromLowerIndexInclusive, subscription, result, cancellationToken).ConfigureAwait(false);
         }
-        
+
+        public async Task ReadForwardByPosition(
+            long fromLowerPositionInclusive,
+            ISubscription subscription,
+            long toUpperPositionInclusive,
+            int limit,
+            CancellationToken cancellationToken)
+        {
+            _lockSlim.EnterReadLock();
+
+            var result = Chunks
+                .Where(x => x.Position >= fromLowerPositionInclusive && x.Position <= toUpperPositionInclusive)
+                .Take(limit)
+                .ToArray();
+
+            _lockSlim.ExitReadLock();
+            await PushToSubscriber(fromLowerPositionInclusive, subscription, result, cancellationToken).ConfigureAwait(false);
+        }
+
         public Task ReadBackward(
             long fromUpperIndexInclusive,
             ISubscription subscription,

--- a/src/NStore.Core/InMemory/InMemoryPersistence.cs
+++ b/src/NStore.Core/InMemory/InMemoryPersistence.cs
@@ -83,11 +83,11 @@ namespace NStore.Core.InMemory
             );
         }
 
-        public async Task ReadForwardMultiplePartitionsAsync(
+        public async Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             IEnumerable<string> partitionIdsList,
-            long fromLowerIndexInclusive,
+            long fromLowerPositionInclusive,
             ISubscription subscription,
-            long toUpperIndexInclusive,
+            long toUpperPositionInclusive,
             CancellationToken cancellationToken)
         {
             if (partitionIdsList is null)
@@ -107,7 +107,7 @@ namespace NStore.Core.InMemory
 
             foreach (var partition in result)
             {
-                await partition.ReadForward(fromLowerIndexInclusive, subscription, toUpperIndexInclusive, Int32.MaxValue, cancellationToken);
+                await partition.ReadForwardByPosition(fromLowerPositionInclusive, subscription, toUpperPositionInclusive, Int32.MaxValue, cancellationToken);
             }
         }
 

--- a/src/NStore.Core/Persistence/IMultiPartitionPersistenceReader.cs
+++ b/src/NStore.Core/Persistence/IMultiPartitionPersistenceReader.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NStore.Core.Persistence
 {
@@ -18,9 +16,9 @@ namespace NStore.Core.Persistence
         /// This is the same as <see cref="IPersistence.ReadForwardAsync"/> but for multiple partitions.
         /// </summary>
         /// <param name="partitionIdsList">List of all partition id I want to read.</param>
-        /// <param name="fromLowerIndexInclusive"></param>
+        /// <param name="fromLowerPositionInclusive">Lower global position to perform a read (included)</param>
         /// <param name="subscription"></param>
-        /// <param name="toUpperIndexInclusive"></param>
+        /// <param name="toUpperPositionInclusive">Upper global position to perform a read (included)</param>
         /// <param name="cancellationToken"></param>
         /// <remarks><para>
         /// We have ZERO guarantee on the order of partition list, we can only assume that
@@ -42,11 +40,11 @@ namespace NStore.Core.Persistence
         /// return a different order.
         /// </para>
         /// </remarks>
-        Task ReadForwardMultiplePartitionsAsync(
+        Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             IEnumerable<string> partitionIdsList,
-            long fromLowerIndexInclusive,
+            long fromLowerPositionInclusive,
             ISubscription subscription,
-            long toUpperIndexInclusive,
+            long toUpperPositionInclusive,
             CancellationToken cancellationToken
         );
     }

--- a/src/NStore.Core/Persistence/LogDecorator.cs
+++ b/src/NStore.Core/Persistence/LogDecorator.cs
@@ -33,16 +33,16 @@ namespace NStore.Core.Persistence
             _logger.LogDebug("End ReadPartitionForward(Partition {PartitionId}, from: {from})", partitionId, fromLowerIndexInclusive);
         }
 
-        public async Task ReadForwardMultiplePartitionsAsync(
+        public async Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             IEnumerable<string> partitionIdsList,
-            long fromLowerIndexInclusive,
+            long fromLowerPositionInclusive,
             ISubscription subscription,
-            long toUpperIndexInclusive,
+            long toUpperPositionInclusive,
             CancellationToken cancellationToken)
         {
-            _logger.LogDebug("Start ReadForwardMultiplePartitionsAsync(Partition {PartitionId}, from: {from})", string.Join(",", partitionIdsList), fromLowerIndexInclusive);
-            await _persistence.ReadForwardMultiplePartitionsAsync(partitionIdsList, fromLowerIndexInclusive, subscription, toUpperIndexInclusive, cancellationToken).ConfigureAwait(false);
-            _logger.LogDebug("End ReadForwardMultiplePartitionsAsync(Partition {PartitionId}, from: {from})", string.Join(",", partitionIdsList), fromLowerIndexInclusive);
+            _logger.LogDebug("Start ReadForwardMultiplePartitionsByGlobalPositionAsync(Partition {PartitionId}, from: {from})", string.Join(",", partitionIdsList), fromLowerPositionInclusive);
+            await _persistence.ReadForwardMultiplePartitionsByGlobalPositionAsync(partitionIdsList, fromLowerPositionInclusive, subscription, toUpperPositionInclusive, cancellationToken).ConfigureAwait(false);
+            _logger.LogDebug("End ReadForwardMultiplePartitionsByGlobalPositionAsync(Partition {PartitionId}, from: {from})", string.Join(",", partitionIdsList), fromLowerPositionInclusive);
         }
 
         public async Task ReadBackwardAsync(

--- a/src/NStore.Core/Persistence/NullPersistence.cs
+++ b/src/NStore.Core/Persistence/NullPersistence.cs
@@ -61,11 +61,11 @@ namespace NStore.Core.Persistence
             return Task.CompletedTask;
         }
 
-        public Task ReadForwardMultiplePartitionsAsync(
+        public Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             IEnumerable<string> partitionIdsList,
-            long fromLowerIndexInclusive,
+            long fromLowerPositionInclusive,
             ISubscription subscription,
-            long toUpperIndexInclusive,
+            long toUpperPositionInclusive,
             CancellationToken cancellationToken)
         {
             return Task.CompletedTask;

--- a/src/NStore.Core/Persistence/PersistenceExtensions.cs
+++ b/src/NStore.Core/Persistence/PersistenceExtensions.cs
@@ -26,17 +26,17 @@ namespace NStore.Core.Persistence
             );
         }
 
-        public static Task ReadForwardMultiplePartitionsAsync(
+        public static Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             this IMultiPartitionPersistenceReader persistence,
             IEnumerable<string> partitionIdsList,
             ISubscription subscription
         )
         {
-            return persistence.ReadForwardMultiplePartitionsAsync(
+            return persistence.ReadForwardMultiplePartitionsByGlobalPositionAsync(
                 partitionIdsList: partitionIdsList,
-                fromLowerIndexInclusive: 0,
+                fromLowerPositionInclusive: 0,
                 subscription: subscription,
-                toUpperIndexInclusive: long.MaxValue,
+                toUpperPositionInclusive: long.MaxValue,
                 cancellationToken: CancellationToken.None
             );
         }
@@ -65,11 +65,11 @@ namespace NStore.Core.Persistence
             ISubscription subscription
         )
         {
-            return persistence.ReadForwardMultiplePartitionsAsync(
+            return persistence.ReadForwardMultiplePartitionsByGlobalPositionAsync(
                 partitionIdsList: partitionIdsList,
-                fromLowerIndexInclusive: fromLowerIndexInclusive,
+                fromLowerPositionInclusive: fromLowerIndexInclusive,
                 subscription: subscription,
-                toUpperIndexInclusive: long.MaxValue,
+                toUpperPositionInclusive: long.MaxValue,
                 cancellationToken: CancellationToken.None
             );
         }
@@ -100,11 +100,11 @@ namespace NStore.Core.Persistence
             long toUpperIndexInclusive
         )
         {
-            return persistence.ReadForwardMultiplePartitionsAsync(
+            return persistence.ReadForwardMultiplePartitionsByGlobalPositionAsync(
                 partitionIdsList,
-                fromLowerIndexInclusive: fromLowerIndexInclusive,
+                fromLowerPositionInclusive: fromLowerIndexInclusive,
                 subscription: subscription,
-                toUpperIndexInclusive: toUpperIndexInclusive,
+                toUpperPositionInclusive: toUpperIndexInclusive,
                 cancellationToken: CancellationToken.None
             );
         }

--- a/src/NStore.Core/Persistence/ProfileDecorator.cs
+++ b/src/NStore.Core/Persistence/ProfileDecorator.cs
@@ -58,11 +58,11 @@ namespace NStore.Core.Persistence
                 )).ConfigureAwait(false);
         }
 
-        public async Task ReadForwardMultiplePartitionsAsync(
+        public async Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             IEnumerable<string> partitionIdsList,
-            long fromLowerIndexInclusive,
+            long fromLowerPositionInclusive,
             ISubscription subscription,
-            long toUpperIndexInclusive,
+            long toUpperPositionInclusive,
             CancellationToken cancellationToken)
         {
             var counter = new SubscriptionWrapper(subscription)
@@ -71,11 +71,11 @@ namespace NStore.Core.Persistence
             };
 
             await ReadForwardCounter.CaptureAsync(() =>
-                _persistence.ReadForwardMultiplePartitionsAsync(
+                _persistence.ReadForwardMultiplePartitionsByGlobalPositionAsync(
                     partitionIdsList,
-                    fromLowerIndexInclusive,
+                    fromLowerPositionInclusive,
                     counter,
-                    toUpperIndexInclusive,
+                    toUpperPositionInclusive,
                     cancellationToken
                 )).ConfigureAwait(false);
         }

--- a/src/NStore.Persistence.LiteDB/LiteDBPersistence.cs
+++ b/src/NStore.Persistence.LiteDB/LiteDBPersistence.cs
@@ -51,21 +51,21 @@ namespace NStore.Persistence.LiteDB
                 .ConfigureAwait(false);
         }
 
-        public async Task ReadForwardMultiplePartitionsAsync(
+        public async Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             IEnumerable<string> partitionIdsList,
-            long fromLowerIndexInclusive,
+            long fromLowerPositionInclusive,
             ISubscription subscription,
-            long toUpperIndexInclusive,
+            long toUpperPositionInclusive,
             CancellationToken cancellationToken)
         {
             var chunks = _streams.Query()
                .Where(x => partitionIdsList.Contains(x.PartitionId)
-                           && x.Index >= fromLowerIndexInclusive
-                           && x.Index <= toUpperIndexInclusive)
-               .OrderBy(x => x.Index)
+                           && x.Position >= fromLowerPositionInclusive
+                           && x.Position <= toUpperPositionInclusive)
+               .OrderBy(x => x.Position)
                .ToList();
 
-            await PublishAsync(chunks, fromLowerIndexInclusive, subscription, false, cancellationToken)
+            await PublishAsync(chunks, fromLowerPositionInclusive, subscription, false, cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/NStore.Persistence.Mongo/MongoPersistence.cs
+++ b/src/NStore.Persistence.Mongo/MongoPersistence.cs
@@ -143,24 +143,24 @@ namespace NStore.Persistence.Mongo
                 cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task ReadForwardMultiplePartitionsAsync(
+        public async Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             IEnumerable<string> partitionIdsList,
-            long fromLowerIndexInclusive,
+            long fromLowerPositionInclusive,
             ISubscription subscription,
-            long toUpperIndexInclusive,
+            long toUpperPositionInclusive,
             CancellationToken cancellationToken)
         {
             var filter = Builders<TChunk>.Filter.And(
                 Builders<TChunk>.Filter.In(x => x.PartitionId, partitionIdsList),
-                Builders<TChunk>.Filter.Gte(x => x.Index, fromLowerIndexInclusive),
-                Builders<TChunk>.Filter.Lte(x => x.Index, toUpperIndexInclusive)
+                Builders<TChunk>.Filter.Gte(x => x.Position, fromLowerPositionInclusive),
+                Builders<TChunk>.Filter.Lte(x => x.Position, toUpperPositionInclusive)
             );
 
-            var sort = Builders<TChunk>.Sort.Ascending(x => x.Index);
+            var sort = Builders<TChunk>.Sort.Ascending(x => x.Position);
             var options = new FindOptions<TChunk>() { Sort = sort };
 
             await PushToSubscriber(
-                fromLowerIndexInclusive,
+                fromLowerPositionInclusive,
                 subscription,
                 options,
                 filter,

--- a/src/NStore.Persistence.MsSql/MsSqlPersistenceOptions.cs
+++ b/src/NStore.Persistence.MsSql/MsSqlPersistenceOptions.cs
@@ -221,15 +221,15 @@ END
 
             if (lowerIndexInclusive > 0 && lowerIndexInclusive != Int64.MinValue)
             {
-                sb.Append("AND [Index] >= @lowerIndexInclusive ");
+                sb.Append("AND [Position] >= @lowerIndexInclusive ");
             }
 
             if (upperIndexInclusive > 0 && upperIndexInclusive != Int64.MaxValue)
             {
-                sb.Append("AND [Index] <= @upperIndexInclusive ");
+                sb.Append("AND [Position] <= @upperIndexInclusive ");
             }
 
-            sb.Append(@descending ? "ORDER BY [Index] DESC" : "ORDER BY [Index]");
+            sb.Append(@descending ? "ORDER BY [Position] DESC" : "ORDER BY [Position]");
 
             return sb.ToString();
         }

--- a/src/NStore.Persistence.Sqlite/SqlitePersistenceOptions.cs
+++ b/src/NStore.Persistence.Sqlite/SqlitePersistenceOptions.cs
@@ -182,15 +182,15 @@ namespace NStore.Persistence.Sqlite
 
             if (lowerIndexInclusive > 0 && lowerIndexInclusive != Int64.MinValue)
             {
-                sb.Append("AND [Index] >= @lowerIndexInclusive ");
+                sb.Append("AND [Position] >= @lowerIndexInclusive ");
             }
 
             if (upperIndexInclusive > 0 && upperIndexInclusive != Int64.MaxValue)
             {
-                sb.Append("AND [Index] <= @upperIndexInclusive ");
+                sb.Append("AND [Position] <= @upperIndexInclusive ");
             }
 
-            sb.Append(descending ? "ORDER BY [Index] DESC" : "ORDER BY [Index]");
+            sb.Append(descending ? "ORDER BY [Position] DESC" : "ORDER BY [Position]");
 
             return sb.ToString();
         }

--- a/src/NStore.Persistence.Tests/PersistenceFixture.cs
+++ b/src/NStore.Persistence.Tests/PersistenceFixture.cs
@@ -1033,7 +1033,7 @@ namespace NStore.Persistence.Tests
         public async Task read_multiple_partition()
         {
             var tape = new Recorder();
-            await Store.ReadForwardMultiplePartitionsAsync(new[] { "mbpra", "mbprb" }, 1, tape, Int32.MaxValue, CancellationToken.None);
+            await Store.ReadForwardMultiplePartitionsByGlobalPositionAsync(new[] { "mbpra", "mbprb" }, 1, tape, Int32.MaxValue, CancellationToken.None);
 
             AssertForBasicRead(tape, 5);
         }
@@ -1044,7 +1044,7 @@ namespace NStore.Persistence.Tests
             var tape = new Recorder();
 
             //Read empty list 
-            await Store.ReadForwardMultiplePartitionsAsync(Array.Empty<string>(), 1, tape, Int32.MaxValue, CancellationToken.None);
+            await Store.ReadForwardMultiplePartitionsByGlobalPositionAsync(Array.Empty<string>(), 1, tape, Int32.MaxValue, CancellationToken.None);
 
             Assert.Empty(tape.Chunks);
         }
@@ -1053,7 +1053,7 @@ namespace NStore.Persistence.Tests
         public async Task read_with_extensions()
         {
             var tape = new Recorder();
-            await Store.ReadForwardMultiplePartitionsAsync(new[] { "mbpra", "mbprb" }, tape);
+            await Store.ReadForwardMultiplePartitionsByGlobalPositionAsync(new[] { "mbpra", "mbprb" }, tape);
 
             AssertForBasicRead(tape, 5);
         }
@@ -1062,7 +1062,7 @@ namespace NStore.Persistence.Tests
         public async Task read_multiple_partition_can_read_single_partition()
         {
             var tape = new Recorder();
-            await Store.ReadForwardMultiplePartitionsAsync(new[] { "mbpra" }, 1, tape, Int32.MaxValue, CancellationToken.None);
+            await Store.ReadForwardMultiplePartitionsByGlobalPositionAsync(new[] { "mbpra" }, 1, tape, Int32.MaxValue, CancellationToken.None);
 
             Assert.Equal(3, tape.Chunks.Count());
             //we could not assume ordering, but clearly b1, is less than b2.
@@ -1085,26 +1085,27 @@ namespace NStore.Persistence.Tests
         public async Task read_limit_version()
         {
             var tape = new Recorder();
-            await Store.ReadForwardMultiplePartitionsAsync(new[] { "mbpra", "mbprb" }, 1, tape, 2, CancellationToken.None);
+            await Store.ReadForwardMultiplePartitionsByGlobalPositionAsync(new[] { "mbpra", "mbprb" }, 1, tape, 4, CancellationToken.None);
 
             AssertForBasicRead(tape, 4);
         }
 
         [Fact]
-        public async Task read_not_from_first_version()
+        public async Task read_single_checkpoint()
         {
             var tape = new Recorder();
-            await Store.ReadForwardMultiplePartitionsAsync(new[] { "mbpra", "mbprb" }, 2, tape, 2, CancellationToken.None);
+            await Store.ReadForwardMultiplePartitionsByGlobalPositionAsync(new[] { "mbpra", "mbprb" }, 2, tape, 2, CancellationToken.None);
 
-            AssertForBasicRead(tape, 2);
+            AssertForBasicRead(tape, 1);
         }
 
         [Fact]
         public async Task read_non_exiting_partition()
         {
             var tape = new Recorder();
-            await Store.ReadForwardMultiplePartitionsAsync(new[] { "mbpra", "does-not-exists" }, 2, tape, 2, CancellationToken.None);
+            await Store.ReadForwardMultiplePartitionsByGlobalPositionAsync(new[] { "mbpra", "does-not-exists" }, 1, tape, 2, CancellationToken.None);
 
+            //read only single chunk of mbpra because the second chunk is from mbprb
             AssertForBasicRead(tape, 1);
         }
 
@@ -1112,7 +1113,7 @@ namespace NStore.Persistence.Tests
         public async Task read_multiple_partition_can_read_no_partition()
         {
             var tape = new Recorder();
-            await Store.ReadForwardMultiplePartitionsAsync(Array.Empty<string>(), 1, tape, Int32.MaxValue, CancellationToken.None);
+            await Store.ReadForwardMultiplePartitionsByGlobalPositionAsync(Array.Empty<string>(), 1, tape, Int32.MaxValue, CancellationToken.None);
 
             Assert.Empty(tape.Chunks);
         }

--- a/src/NStore.Tpl/PersistenceBatchAppendDecorator.cs
+++ b/src/NStore.Tpl/PersistenceBatchAppendDecorator.cs
@@ -60,18 +60,18 @@ namespace NStore.Tpl
                 toUpperIndexInclusive, limit, cancellationToken);
         }
 
-        public Task ReadForwardMultiplePartitionsAsync(
+        public Task ReadForwardMultiplePartitionsByGlobalPositionAsync(
             IEnumerable<string> partitionIdsList,
-            long fromLowerIndexInclusive,
+            long fromLowerPositionInclusive,
             ISubscription subscription,
-            long toUpperIndexInclusive,
+            long toUpperPositionInclusive,
             CancellationToken cancellationToken)
         {
-            return _persistence.ReadForwardMultiplePartitionsAsync(
+            return _persistence.ReadForwardMultiplePartitionsByGlobalPositionAsync(
                 partitionIdsList,
-                fromLowerIndexInclusive,
+                fromLowerPositionInclusive,
                 subscription,
-                toUpperIndexInclusive,
+                toUpperPositionInclusive,
                 cancellationToken);
         }
 


### PR DESCRIPTION
Previous logic is based on aggregate index, and it is absolutely not useful, it is logic to use only the global position to perform a multi partition read.

Ask for @AGiorgetti for review